### PR TITLE
Use aspect ratio 16:9 instead of old 4:3

### DIFF
--- a/beamerthemeUiBCSD.sty
+++ b/beamerthemeUiBCSD.sty
@@ -317,38 +317,45 @@
 {
     \hbox to \paperwidth
     {%
-        \begin{beamercolorbox}[wd = 0.33\paperwidth,
+        \begin{beamercolorbox}[wd = 0.30\paperwidth,
                                ht = 2.25ex,
                                dp = 1ex]
                               {section in head/foot}
 
-                \hfil
+                \hspace*{\fill}
                 \usebeamerfont{author in head/foot}
                 \insertshortauthor
-                \hfil
+                \hspace*{\fill}
         \end{beamercolorbox}%
-        \begin{beamercolorbox}[wd = 0.34\paperwidth,
+        \begin{beamercolorbox}[wd = 0.30\paperwidth,
                                ht = 2.25ex,
                                dp = 1ex]
                               {section in head/foot}
 
-                \hfil
+                \hspace*{\fill}
                 \usebeamerfont{title in head/foot}
                 % \insertshorttitle
                 \insertsection
-                \hfil
+                \hspace*{\fill}
         \end{beamercolorbox}%
-        \begin{beamercolorbox}[wd = 0.33\paperwidth,
+        \begin{beamercolorbox}[wd = 0.30\paperwidth,
                                ht = 2.25ex,
                                dp = 1ex]
                               {section in head/foot}
 
-                \hfil
+                \hspace*{\fill}
                 \usebeamerfont{date in head/foot}
                 \insertshortdate
-                \hspace*{2em}
+                \hspace*{\fill}
+        \end{beamercolorbox}%
+        \begin{beamercolorbox}[wd = 0.10\paperwidth,
+                               ht = 2.25ex,
+                               dp = 1ex]
+                              {section in head/foot}
+
+                \hspace*{\fill}
                 \insertframenumber{} / \inserttotalframenumber
-                \hspace*{2ex}
+                \hspace*{\fill}
         \end{beamercolorbox}
     }
     \vskip0pt

--- a/main.tex
+++ b/main.tex
@@ -1,4 +1,4 @@
-\documentclass[UKenglish]{beamer}
+\documentclass[UKenglish, aspectratio=169]{beamer}
 
 
 \usetheme{UiBCSD}

--- a/main.tex
+++ b/main.tex
@@ -178,7 +178,8 @@
         \end{column}
     \end{columns}
     
-    \begin{textblock}{0.3}(0.45, 0.55)
+    \begin{textblock}{0.3}(0.625, 0.45)
+        \centering
         \includegraphics<1, 3>[width = \textwidth]{UiB-CSD-images/UiB-emblem.pdf}
     \end{textblock}
 \end{frame}


### PR DESCRIPTION
- Enforce use of aspect ratio 16:9
- Fix footline to be in accordance to new aspect ratio
- Fix place of uib logo in effects slides